### PR TITLE
Use apk instead of apt-get in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /usr/src/app
 COPY ["package.json", "package-lock.json*", "npm-shrinkwrap.json*", "./"]
 RUN npm install --production --silent && mv node_modules ../
 COPY . .
-RUN apt-get install nano
+RUN apk add nano
 EXPOSE 3000
 CMD npm start


### PR DESCRIPTION
Alpine Linux uses apk to manage packages. The Dockerfile currently fails to build and this fixes it (unless you want the base image to be Ubuntu or Debian)